### PR TITLE
fix typo in ws.js

### DIFF
--- a/lib/ws.js
+++ b/lib/ws.js
@@ -17,7 +17,7 @@ class BinanceWS {
         const ws = new WebSocket(path);
         ws.on('message', (json) => {
             const data = JSON.parse(json);
-            eventHandler(this._beautifier.beautifier(data, data.e + 'Event'));
+            eventHandler(this._beautifier.beautify(data, data.e + 'Event'));
         });
         return ws;
     }


### PR DESCRIPTION
First of all thanks for creating this wrapper, it's really helpful. 👍 

### Issue
I was trying to use this wrapper to connect to the Finance web socket and got this error:

```
/Users/aslam/Documents/projects/gdax/node_modules/binance/lib/ws.js:20
            eventHandler(this._beautifier.beautifier(data, data.e + 'Event'));
                                          ^

TypeError: this._beautifier.beautifier is not a function
    at WebSocket.ws.on (/Users/aslam/Documents/projects/gdax/node_modules/binance/lib/ws.js:20:43)
    at emitOne (events.js:115:13)
    at WebSocket.emit (events.js:210:7)
    at Receiver._receiver.onmessage (/Users/aslam/Documents/projects/gdax/node_modules/ws/lib/WebSocket.js:143:47)
    at Receiver.dataMessage (/Users/aslam/Documents/projects/gdax/node_modules/ws/lib/Receiver.js:389:14)
    at Receiver.getData (/Users/aslam/Documents/projects/gdax/node_modules/ws/lib/Receiver.js:330:12)
    at Receiver.startLoop (/Users/aslam/Documents/projects/gdax/node_modules/ws/lib/Receiver.js:165:16)
    at Receiver.add (/Users/aslam/Documents/projects/gdax/node_modules/ws/lib/Receiver.js:139:10)
    at TLSSocket._ultron.on (/Users/aslam/Documents/projects/gdax/node_modules/ws/lib/WebSocket.js:139:22)
    at emitOne (events.js:115:13)
    at TLSSocket.emit (events.js:210:7)
    at addChunk (_stream_readable.js:266:12)
    at readableAddChunk (_stream_readable.js:253:11)
    at TLSSocket.Readable.push (_stream_readable.js:211:10)
    at TLSWrap.onread (net.js:585:20)
```

### How to fix

There is a typo in `ws.js`. In this line:

> eventHandler(this._beautifier.beautifier(data, data.e + 'Event'));

It should be:

> eventHandler(this._beautifier.beautify(data, data.e + 'Event')); 