### PR TITLE
修复接口调用错误时,JSON.parse抛出异常

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -67,7 +67,13 @@ class BinanceRest {
                     if (err) {
                         reject(err);
                     } else if (response.statusCode < 200 || response.statusCode > 299) {
-                        reject(JSON.parse(body));
+                        try {
+                            reject(JSON.parse(body));
+                        }
+                        catch (e) {
+                            reject(body);
+                        }
+                        
                     } else {
                         let payload = JSON.parse(body);
                         if (_.isArray(payload)) {


### PR DESCRIPTION
某些时候body可能如下，这样JSON.parse会报错。

```

<html>
<head>
    <title>500 Internal Server Error</title>
</head>
<body bgcolor="white">
    <center>
        <h1>500 Internal Server Error</h1>
    </center>
</body>
</html>

```