### PR TITLE
Produce a real Error object on HTTP errors

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -63,7 +63,7 @@ class BinanceRest {
                     payload = body;
                 }
                 if (err || response.statusCode < 200 || response.statusCode > 299) {
-                    callback(err || payload, payload);
+                    callback(err || new Error(`Response code ${response.statusCode}`), payload);
                 } else {
                     if (_.isArray(payload)) {
                         payload = _.map(payload, (item) => {


### PR DESCRIPTION
When an HTTP 4XX or 5XX error is returned, the payload will be a PNG image returned by Binance, instead of passing this back as the error we send an error object with the response code. This allows error handling to be implemented, including the ability to respond to rate limits.