### PR TITLE
Add top level type definitions for TypeScript users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.idea/
 node_modules/
 util/config.js
 coverage/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,55 @@
+type Callback = (err: Error, data: object) => void;
+
+declare class BinanceRest {
+  new({
+    key,
+    secret,
+    recvWindow,
+    timeout,
+    disableBeautification,
+    handleDrift
+  }: {
+    key: string,
+    secret: string,
+    recvWindow?: number,
+    timeout?: number,
+    disableBeautification?: boolean,
+    handleDrift?: boolean
+  }): BinanceRest;
+
+  account: (query: object | Callback, callback?: Callback) => Promise<object> | void;
+
+  aggTrades: (query: object | string, callback?: Callback) => Promise<object> | void;
+
+  allBookTickers: (callback?: Callback) => Promise<object> | void;
+
+  allOrders: (query: object | string, callback?: Callback) => Promise<object> | void;
+
+  allPrices: (callback?: Callback) => Promise<object> | void;
+
+  bookTicker: (query: object, callback?: Callback) => Promise<object> | void;
+
+  exchangeInfo: (callback?: Callback) => Promise<object> | void;
+
+  historicalTrades: (query: object | string, callback?: Callback) => Promise<object> | void;
+
+  depth: (query: object | string, callback?: Callback) => Promise<object> | void;
+
+  klines: (query: object, callback?: Callback) => Promise<object> | void;
+
+  ping: (callback?: Callback) => Promise<object> | void;
+
+  ticker24hr: (query: object, callback?: Callback) => Promise<object> | void;
+
+  tickerPrice: (query: object, callback?: Callback) => Promise<object> | void;
+
+  time: (callback?: Callback) => Promise<object> | void;
+
+  trades: (query: object | string, callback?: Callback) => Promise<object> | void;
+}
+
+declare class Beautifier {
+  new(): Beautifier
+
+  beautify(obj: object, type: object | string): object
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "Gavy Aggarwal (http://gavyaggarwal.com/)"
   ],
   "license": "MIT",
+  "types": "index.d.ts",
   "devDependencies": {
     "chai": "^4.1.1",
     "coveralls": "^3.0.0",


### PR DESCRIPTION
This is a basic start for supporting TypeScript developers. The `index.d.ts` file defines `BinanceRest` and its public API.

If people fine this useful they should open more PRs that define the response objects for each public function.

See #14 for the original issue.